### PR TITLE
Disable zoom on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, 
+     user-scalable=0"
+    />
     <title>Virgil — The font that powers Excalidraw</title>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css"


### PR DESCRIPTION
I've tested it on Brave & Chrome on mobile and it works. May I know why we are doing this?

Fixes #35 